### PR TITLE
Logoview update

### DIFF
--- a/OfficeUIFabricCore/OfficeUIFabricCore/Components/Common/InitialsView/InitialsView.swift
+++ b/OfficeUIFabricCore/OfficeUIFabricCore/Components/Common/InitialsView/InitialsView.swift
@@ -27,6 +27,7 @@ public class InitialsView: UIView {
         self.initialsLabel.translatesAutoresizingMaskIntoConstraints = false
         self.initialsLabel.font = UIFont.msFont(MSFontStyle.XL, weight: MSFontWeight.Regular)
         self.initialsLabel.textColor = UIColor.msNeutralWhite()
+        self.initialsLabel.clipsToBounds = true
         self.addSubview(self.initialsLabel)
         self.setUpConstraints()
     }

--- a/OfficeUIFabricCore/OfficeUIFabricCore/Components/Common/InitialsView/StringInitialsExtension.swift
+++ b/OfficeUIFabricCore/OfficeUIFabricCore/Components/Common/InitialsView/StringInitialsExtension.swift
@@ -4,7 +4,7 @@ import UIKit
 
 extension String {
     internal func words() -> [String] {
-        let range = Range<String.Index>(start: self.startIndex, end: self.endIndex)
+        let range = self.startIndex ..< self.endIndex
         var words = [String]()
         
         self.enumerateSubstringsInRange(range, options: .ByWords) { (word, _, _, _) -> () in

--- a/OfficeUIFabricCore/OfficeUIFabricCore/Components/Common/LogoView/LogoView.swift
+++ b/OfficeUIFabricCore/OfficeUIFabricCore/Components/Common/LogoView/LogoView.swift
@@ -20,6 +20,8 @@ public class LogoView: UIView {
     
     private func setupSubviews() {
         self.imageView.contentMode = UIViewContentMode.ScaleAspectFit
+        self.imageView.clipsToBounds = true
+        self.initialsView.clipsToBounds = true
         self.setupSubview(self.imageView)
         self.setupSubview(self.initialsView)
     }


### PR DESCRIPTION
Small update for LogoView and InitialsView

Includes:
- Update Range operator usage (current operator will be removed in Swift 3.x)
- `ClipToBounds` default value
