### PR TITLE
Fix demo app crash for Swift 3.

### DIFF
--- a/OfficeUIFabricDemo/OfficeUIFabricDemo/DemoControllers/Customization/ButtonDemoViewController.swift
+++ b/OfficeUIFabricDemo/OfficeUIFabricDemo/DemoControllers/Customization/ButtonDemoViewController.swift
@@ -23,7 +23,7 @@ class ButtonDemoViewController: UIViewController {
         self.disabledPrimaryButton.msPrimaryButton()
     }
     
-    @IBAction func toggleButtonTap(sender: AnyObject) {
+    @IBAction func toggleButtonTap(_ sender: AnyObject) {
         if let button = sender as? UIButton {
             button.isSelected = !button.isSelected
             button.tintColor = button.titleColor(for: button.isSelected ? UIControlState.selected : UIControlState())

--- a/OfficeUIFabricDemo/OfficeUIFabricDemo/DemoControllers/Customization/TextFieldDemoViewController.swift
+++ b/OfficeUIFabricDemo/OfficeUIFabricDemo/DemoControllers/Customization/TextFieldDemoViewController.swift
@@ -41,7 +41,7 @@ class TextFieldDemoViewController: UIViewController {
         self.permPlaceholderUnderlineTextField.msTextFieldPermanentPlaceholderText(text: "Last Name", font: self.permPlaceholderBoxTextField.font)
     }
     
-    @IBAction func hideKeyboard(sender: AnyObject) {
+    @IBAction func hideKeyboard(_ sender: AnyObject) {
         self.defaultBoxTextField.resignFirstResponder()
         self.defaultUnderlineTextField.resignFirstResponder()
         self.customBoxTextField.resignFirstResponder()


### PR DESCRIPTION
Currently demo application crashes when toggle button tapped.

The error message is below.

```
-[OfficeUIFabricDemo.ButtonDemoViewController toggleButtonTap:]: unrecognized selector sent to instance
```

In ButtonDemoViewController.swift

```
@IBAction func toggleButtonTap(sender: AnyObject)
```

Above method is recognized as `toggleButtonTapWithSender:` on storyboard with Swift 3.
It needs to omit argument label as below using underbar. 

```
@IBAction func toggleButtonTap(_ sender: AnyObject)
```

This is recognized as `toggleButtonTap:` on storyboard as before.

---

It's same with TextFieldDemoViewController.swift.

```
@IBAction func hideKeyboard(sender: AnyObject)
```

Above method needs to be modified as below.

```
@IBAction func hideKeyboard(_ sender: AnyObject)
```
